### PR TITLE
Include search over new possible directories for MagickWand in Debian 8

### DIFF
--- a/imagemagick.m4
+++ b/imagemagick.m4
@@ -27,32 +27,34 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
 
   AC_MSG_CHECKING(ImageMagick MagickWand API configuration program)
 
+  LMW_ARRAY=$(find /usr/lib/ -name *Wand-config -exec dirname {} \;)
+
   if test "$2" != "yes"; then
-    for i in "$2" /usr/local /usr /opt /opt/local;
+    for i in "$2/bin" /usr/local/bin /usr/bin /opt/bin /opt/local/bin $LMW_ARRAY;
     do
-      if test -r "${i}/bin/MagickWand-config"; then
-        IM_WAND_BINARY="${i}/bin/MagickWand-config"
+      if test -r "${i}/MagickWand-config"; then
+        IM_WAND_BINARY="${i}/MagickWand-config"
         IM_IMAGEMAGICK_PREFIX=$i
         break
       fi
 
-      if test -r "${i}/bin/Wand-config"; then
-        IM_WAND_BINARY="${i}/bin/Wand-config"
+      if test -r "${i}/Wand-config"; then
+        IM_WAND_BINARY="${i}/Wand-config"
         IM_IMAGEMAGICK_PREFIX=$i
         break
       fi
     done
   else
-    for i in /usr/local /usr /opt /opt/local;
+    for i in /usr/local /usr /opt /opt/local $LMW_ARRAY;
     do
-      if test -r "${i}/bin/MagickWand-config"; then
-        IM_WAND_BINARY="${i}/bin/MagickWand-config"
+      if test -r "${i}/MagickWand-config"; then
+        IM_WAND_BINARY="${i}/MagickWand-config"
         IM_IMAGEMAGICK_PREFIX=$i
         break
       fi
 
-      if test -r "${i}/bin/Wand-config"; then
-        IM_WAND_BINARY="${i}/bin/Wand-config"
+      if test -r "${i}/Wand-config"; then
+        IM_WAND_BINARY="${i}/Wand-config"
         IM_IMAGEMAGICK_PREFIX=$i
         break
       fi
@@ -143,4 +145,3 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
   export IM_IMAGEMAGICK_LIBS
   export IM_IMAGEMAGICK_CFLAGS
 ])
-


### PR DESCRIPTION
Since Debian8 libmagickwand does not reside in /usr/bin anymore but in one of following (depending on architecture):

/usr/lib/aarch64-linux-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/arm-linux-gnueabi/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/arm-linux-gnueabihf/ImageMagick-6.8.9/bin-Q16/MagickWand-config 
/usr/lib/i386-kfreebsd-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/i386-linux-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/mips-linux-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/mipsel-linux-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/powerpc-linux-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/powerpc64le-linux-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/s390x-linux-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/x86_64-kfreebsd-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config
/usr/lib/x86_64-linux-gnu/ImageMagick-6.8.9/bin-Q16/MagickWand-config


/usr/bin/MagickWand-config on sparc, ia64, s390.
For more info please refer to: https://packages.debian.org/search?searchon=contents&keywords=MagickWand-config&mode=filename&suite=stable&arch=any

Adding this fix to repo fixes faliling ./configure (missing MagickWand-config).