### PR TITLE
fix zbar_version

### DIFF
--- a/zbarcode.c
+++ b/zbarcode.c
@@ -827,12 +827,12 @@ PHP_MSHUTDOWN_FUNCTION(zbarcode)
 */
 PHP_MINFO_FUNCTION(zbarcode)
 {
-	unsigned int major = 0, minor = 0;
+	unsigned int major = 0, minor = 0, patch = 0;
 	char *zbar_ver = NULL;
 	unsigned long magick_version;
 
-	zbar_version(&major, &minor);
-	spprintf(&zbar_ver, 24, "%d.%d", major, minor);
+	zbar_version(&major, &minor, &patch);
+	spprintf(&zbar_ver, 24, "%d.%d.%d", major, minor,patch);
 
 	php_info_print_table_start();
 	php_info_print_table_row(2, "zbarcode module",			"enabled");


### PR DESCRIPTION
add patch
fixed: error: too few arguments to function ‘zbar_version’

ubuntu 20
php 7.4.25
make  error 
